### PR TITLE
Optional <?chance> config option for DeathSpawn

### DIFF
--- a/src/main/java/quarris/rotm/config/EntityConfig.java
+++ b/src/main/java/quarris/rotm/config/EntityConfig.java
@@ -92,17 +92,19 @@ public class EntityConfig implements ISubConfig {
     @Config.Name("Death Spawns")
     @Config.Comment({
             "Death Spawns allows mobs to be summoned when an entity dies.",
-            "Format: <modid:entity>;<modid:spawn>;<spawnRange>;<disableXP>;<disableLoot>;<autoAggro>;<?sound>;?<nbt>",
+            "Format: <modid:entity>;<modid:spawn>;<spawnRange>;<disableXP>;<disableLoot>;<autoAggro>;<?sound>;?<nbt>;<?chance>",
             "Where: <modid:master> and <modid:spawn> are the entities for the entity that dies and the mob that spawns respectively.",
             "<spawnRange> is the min-max range of summons that can spawn in one cycle.",
             "<disableXP> and <disableLoot> are true/false values and will make it so that the summoned entities do not drop XP or Loot respectively",
             "<autoAggro> is a true/false value will set the summoned entities to aggro onto the target of the dying entity if set to true",
             "<?sound> is the (optional) sound that will be played when the summon happens",
             "?<nbt> optional NBT to apply to the summon on spawn.",
+            "<?chance> is the (optional) percentage (0-100 exclusive-inclusive) chance that the summons will spawn (100 by default).",
             "Example:",
             "S:\"Death Spawns\" <",
             "   minecraft:zombie;minecraft:spider;2-5;true;false;true;minecraft:ambient.cave",
             "   minecraft:zombie;minecraft:villager;1;false;false;false;minecraft:entity.enderdragon.growl;{NoAI:1b}",
+            "   minecraft:zombie;minecraft:villager;1;false;false;false;minecraft:entity.enderdragon.growl;{NoAI:1b};50",
             ">",
     })
     public String[] rawDeathSpawns = new String[]{};
@@ -279,7 +281,8 @@ public class EntityConfig implements ISubConfig {
                                 ROTM.logger.warn("Could not parse NBT for {}; {}", s, e.getMessage());
                             }
                             return new NBTTagCompound();
-                        }).accept(builder::nbt);
+                        }).accept(builder::nbt)
+                        .next().optional((float) 100).parseAs(Float::parseFloat).<Float>validate(chance -> chance > 0 && chance <= 100).accept(builder::chance);
             } catch (StringConfigException exception) {
                 ROTM.logger.warn("Could not parse config; skipping {}\n{}", s, exception.getLocalizedMessage());
             }

--- a/src/main/java/quarris/rotm/config/types/DeathSpawnType.java
+++ b/src/main/java/quarris/rotm/config/types/DeathSpawnType.java
@@ -12,8 +12,9 @@ public class DeathSpawnType {
     public final boolean autoAggro;
     public final ResourceLocation sound;    // The sound to be played when the summon happens
     public final NBTTagCompound nbt;        // NBT to apply to the summoned entity on spawn
+    public final float chance;              // Chance that the mobs are spawned
 
-    public DeathSpawnType(ResourceLocation summon, int minSpawn, int maxSpawn, boolean disableXP, boolean disableLoot, boolean autoAggro, ResourceLocation sound, NBTTagCompound nbt) {
+    public DeathSpawnType(ResourceLocation summon, int minSpawn, int maxSpawn, boolean disableXP, boolean disableLoot, boolean autoAggro, ResourceLocation sound, NBTTagCompound nbt, float chance) {
         this.summon = summon;
         this.minSpawn = minSpawn;
         this.maxSpawn = maxSpawn;
@@ -22,6 +23,7 @@ public class DeathSpawnType {
         this.autoAggro = autoAggro;
         this.sound = sound;
         this.nbt = nbt;
+        this.chance = chance;
     }
 
     public static Builder builder() {
@@ -38,6 +40,7 @@ public class DeathSpawnType {
         sb.append(", disableLoot=").append(disableLoot);
         sb.append(", sound=").append(sound);
         sb.append(", nbt=").append(nbt);
+        sb.append(", chance=").append(chance);
         sb.append('}');
         return sb.toString();
     }
@@ -51,6 +54,8 @@ public class DeathSpawnType {
         public ResourceLocation sound;    // The sound to be played when the summon happens
         public NBTTagCompound nbt;
         public boolean autoAggro;
+        public float chance;              // Chance that the mobs are spawned
+
 
         Builder() { }
 
@@ -95,8 +100,13 @@ public class DeathSpawnType {
             return this;
         }
 
+        public Builder chance(float chance) {
+            this.chance = chance;
+            return this;
+        }
+
         public DeathSpawnType build() {
-            return new DeathSpawnType(summon, minSpawn, maxSpawn, disableXP, disableLoot, autoAggro, sound, nbt);
+            return new DeathSpawnType(summon, minSpawn, maxSpawn, disableXP, disableLoot, autoAggro, sound, nbt, chance);
         }
     }
 }

--- a/src/main/java/quarris/rotm/event/EntityEventHandler.java
+++ b/src/main/java/quarris/rotm/event/EntityEventHandler.java
@@ -115,6 +115,7 @@ public class EntityEventHandler {
                 .forEach(spawn -> {
                     Random random = new Random();
                     int amount = spawn.minSpawn + random.nextInt(spawn.maxSpawn - spawn.minSpawn + 1);
+                    if (random.nextFloat()*100 > spawn.chance) amount = 0;
                     boolean spawned = false;
                     for (int i = 0; i < amount; i++) {
                         Entity toSpawn = EntityList.createEntityByIDFromName(spawn.summon, entity.world);


### PR DESCRIPTION
Adds a chance config option to DeathSpawn event, as requested by a user on CurseForge.
I thought it was easy enough to implement so here it is.